### PR TITLE
Adjust versioning database code to schema changes

### DIFF
--- a/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
@@ -37,46 +37,10 @@ namespace osu.Server.BeatmapSubmission.Tests
             db.Execute("TRUNCATE TABLE `phpbb_users`");
             db.Execute("TRUNCATE TABLE `osu_beatmaps`");
 
-            // temporarily (re)create tables for versioning ourselves until they are added to osu-web
-            db.Execute("DROP TABLE IF EXISTS `osu_beatmapset_version_files`");
-            db.Execute("DROP TABLE IF EXISTS `osu_beatmapset_files`");
-            db.Execute("DROP TABLE IF EXISTS `osu_beatmapset_versions`");
+            db.Execute("TRUNCATE TABLE `beatmapset_version_files`");
+            db.Execute("TRUNCATE TABLE `beatmapset_files`");
+            db.Execute("TRUNCATE TABLE `beatmapset_versions`");
             db.Execute("TRUNCATE TABLE `osu_beatmapsets`");
-
-            db.Execute(
-                """
-                CREATE TABLE `osu_beatmapset_files` (
-                    `file_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-                    `sha2_hash` BINARY(32) NOT NULL,
-                    `file_size` INT UNSIGNED NOT NULL,
-                    
-                    UNIQUE (`sha2_hash`)
-                )
-                """);
-            db.Execute(
-                """
-                CREATE TABLE `osu_beatmapset_versions` (
-                    `version_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-                    `beatmapset_id` MEDIUMINT UNSIGNED NOT NULL,
-                    `created_at` DATETIME NOT NULL DEFAULT NOW(),
-                    `previous_version_id` BIGINT UNSIGNED NULL DEFAULT NULL,
-                    
-                    FOREIGN KEY (`beatmapset_id`) REFERENCES osu_beatmapsets(`beatmapset_id`),
-                    FOREIGN KEY (`previous_version_id`) REFERENCES osu_beatmapset_versions(`version_id`)
-                )
-                """);
-            db.Execute(
-                """
-                CREATE TABLE `osu_beatmapset_version_files` (
-                    `file_id` BIGINT UNSIGNED NOT NULL,
-                    `version_id` BIGINT UNSIGNED NOT NULL,
-                    `filename` VARCHAR(500) NOT NULL,
-                    
-                    PRIMARY KEY (`file_id`, `version_id`),
-                    FOREIGN KEY (`file_id`) REFERENCES osu_beatmapset_files(`file_id`),
-                    FOREIGN KEY (`version_id`) REFERENCES osu_beatmapset_versions(`version_id`)
-                )
-                """);
         }
 
         protected void WaitForDatabaseState<T>(string sql, T expected, CancellationToken cancellationToken, object? param = null)

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -257,7 +257,7 @@ namespace osu.Server.BeatmapSubmission
         {
             using var db = DatabaseAccess.GetConnection();
 
-            (osu_beatmapset_version version, VersionedFile[] files)? versionInfo = await db.GetBeatmapsetVersionAsync(beatmapSetId, versionId);
+            (beatmapset_version version, VersionedFile[] files)? versionInfo = await db.GetBeatmapsetVersionAsync(beatmapSetId, versionId);
 
             if (versionInfo == null)
                 return NotFound();

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -134,10 +134,10 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
-        public static async Task<ulong> InsertBeatmapsetFileAsync(this MySqlConnection db, osu_beatmapset_file file, MySqlTransaction? transaction = null)
+        public static async Task<ulong> InsertBeatmapsetFileAsync(this MySqlConnection db, beatmapset_file file, MySqlTransaction? transaction = null)
         {
-            var existing = await db.QuerySingleOrDefaultAsync<osu_beatmapset_file?>(
-                "SELECT * FROM `osu_beatmapset_files` WHERE `sha2_hash` = @sha2_hash",
+            var existing = await db.QuerySingleOrDefaultAsync<beatmapset_file?>(
+                "SELECT * FROM `beatmapset_files` WHERE `sha2_hash` = @sha2_hash",
                 file,
                 transaction);
 
@@ -150,15 +150,15 @@ namespace osu.Server.BeatmapSubmission
             }
 
             return file.file_id = await db.QuerySingleAsync<ulong>(
-                "INSERT INTO `osu_beatmapset_files` (`sha2_hash`, `file_size`) VALUES (@sha2_hash, @file_size) AS `new`; SELECT LAST_INSERT_ID();",
+                "INSERT INTO `beatmapset_files` (`sha2_hash`, `file_size`) VALUES (@sha2_hash, @file_size) AS `new`; SELECT LAST_INSERT_ID();",
                 file,
                 transaction);
         }
 
-        public static async Task<(osu_beatmapset_version, VersionedFile[])?> GetBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, ulong versionId, MySqlTransaction? transaction = null)
+        public static async Task<(beatmapset_version, VersionedFile[])?> GetBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, ulong versionId, MySqlTransaction? transaction = null)
         {
-            var version = await db.QuerySingleOrDefaultAsync<osu_beatmapset_version?>(
-                "SELECT * FROM `osu_beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id AND `version_id` = @version_id",
+            var version = await db.QuerySingleOrDefaultAsync<beatmapset_version?>(
+                "SELECT * FROM `beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id AND `version_id` = @version_id",
                 new
                 {
                     beatmapset_id = beatmapSetId,
@@ -170,11 +170,11 @@ namespace osu.Server.BeatmapSubmission
 
             VersionedFile[] files = (await db.QueryAsync(
                 """
-                SELECT `f`.`file_id`, `f`.`sha2_hash`, `f`.`file_size`, `vf`.`file_id` AS `versioned_file_id`, `vf`.`version_id`, `vf`.`filename` FROM `osu_beatmapset_files` `f`
-                JOIN `osu_beatmapset_version_files` `vf` ON `f`.`file_id` = `vf`.`file_id`
+                SELECT `f`.`file_id`, `f`.`sha2_hash`, `f`.`file_size`, `vf`.`file_id` AS `versioned_file_id`, `vf`.`version_id`, `vf`.`filename` FROM `beatmapset_files` `f`
+                JOIN `beatmapset_version_files` `vf` ON `f`.`file_id` = `vf`.`file_id`
                 WHERE `vf`.`version_id` = @version_id
                 """,
-                (osu_beatmapset_file file, osu_beatmapset_version_file versionFile) => new VersionedFile(file, versionFile),
+                (beatmapset_file file, beatmapset_version_file versionFile) => new VersionedFile(file, versionFile),
                 new
                 {
                     version_id = version.version_id
@@ -188,7 +188,7 @@ namespace osu.Server.BeatmapSubmission
         public static async Task<ulong> CreateBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)
         {
             ulong? previousVersion = await db.QuerySingleAsync<ulong?>(
-                "SELECT MAX(`version_id`) FROM `osu_beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id",
+                "SELECT MAX(`version_id`) FROM `beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id",
                 new
                 {
                     beatmapset_id = beatmapSetId
@@ -196,7 +196,7 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
 
             return await db.QuerySingleAsync<ulong>(
-                "INSERT INTO `osu_beatmapset_versions` (`beatmapset_id`, `previous_version_id`) VALUES (@beatmapset_id, @previous_version_id); SELECT LAST_INSERT_ID();",
+                "INSERT INTO `beatmapset_versions` (`beatmapset_id`, `previous_version_id`) VALUES (@beatmapset_id, @previous_version_id); SELECT LAST_INSERT_ID();",
                 new
                 {
                     beatmapset_id = beatmapSetId,
@@ -205,10 +205,10 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
-        public static Task InsertBeatmapsetVersionFileAsync(this MySqlConnection db, osu_beatmapset_version_file versionFile, MySqlTransaction? transaction = null)
+        public static Task InsertBeatmapsetVersionFileAsync(this MySqlConnection db, beatmapset_version_file versionFile, MySqlTransaction? transaction = null)
         {
             return db.ExecuteAsync(
-                "INSERT INTO `osu_beatmapset_version_files` (`file_id`, `version_id`, `filename`) VALUES (@file_id, @version_id, @filename)",
+                "INSERT INTO `beatmapset_version_files` (`file_id`, `version_id`, `filename`) VALUES (@file_id, @version_id, @filename)",
                 versionFile,
                 transaction);
         }

--- a/osu.Server.BeatmapSubmission/Models/Database/beatmapset_file.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/beatmapset_file.cs
@@ -5,10 +5,10 @@
 
 namespace osu.Server.BeatmapSubmission.Models.Database
 {
-    public class osu_beatmapset_version_file
+    public class beatmapset_file
     {
         public ulong file_id { get; set; }
-        public ulong version_id { get; set; }
-        public string filename { get; set; } = string.Empty;
+        public byte[] sha2_hash { get; set; } = new byte[32];
+        public uint file_size { get; set; }
     }
 }

--- a/osu.Server.BeatmapSubmission/Models/Database/beatmapset_version.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/beatmapset_version.cs
@@ -5,7 +5,7 @@
 
 namespace osu.Server.BeatmapSubmission.Models.Database
 {
-    public class osu_beatmapset_version
+    public class beatmapset_version
     {
         public ulong version_id { get; set; }
         public uint beatmapset_id { get; set; }

--- a/osu.Server.BeatmapSubmission/Models/Database/beatmapset_version_file.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/beatmapset_version_file.cs
@@ -5,10 +5,10 @@
 
 namespace osu.Server.BeatmapSubmission.Models.Database
 {
-    public class osu_beatmapset_file
+    public class beatmapset_version_file
     {
         public ulong file_id { get; set; }
-        public byte[] sha2_hash { get; set; } = new byte[32];
-        public uint file_size { get; set; }
+        public ulong version_id { get; set; }
+        public string filename { get; set; } = string.Empty;
     }
 }

--- a/osu.Server.BeatmapSubmission/Models/VersionedFile.cs
+++ b/osu.Server.BeatmapSubmission/Models/VersionedFile.cs
@@ -5,9 +5,9 @@ using osu.Server.BeatmapSubmission.Models.Database;
 
 namespace osu.Server.BeatmapSubmission.Models
 {
-    public readonly struct VersionedFile(osu_beatmapset_file file, osu_beatmapset_version_file versionFile)
+    public readonly struct VersionedFile(beatmapset_file file, beatmapset_version_file versionFile)
     {
-        public osu_beatmapset_file File { get; } = file;
-        public osu_beatmapset_version_file VersionFile { get; } = versionFile;
+        public beatmapset_file File { get; } = file;
+        public beatmapset_version_file VersionFile { get; } = versionFile;
     }
 }

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
@@ -30,12 +30,12 @@ namespace osu.Server.BeatmapSubmission.Services
             {
                 var stream = archiveReader.GetStream(filename);
                 files.Add(new VersionedFile(
-                    new osu_beatmapset_file
+                    new beatmapset_file
                     {
                         sha2_hash = SHA256.HashData(stream),
                         file_size = (uint)stream.Length,
                     },
-                    new osu_beatmapset_version_file
+                    new beatmapset_version_file
                     {
                         filename = filename,
                     }


### PR DESCRIPTION
See https://github.com/ppy/osu-web/pull/11668.

Basically boils down to the `osu_` prefix removal. The change of `DATETIME` to `TIMESTAMP` doesn't really affect much in the data typing.

If wanting to run locally and `docker compose up` was already ran at least once, you'll probably want a `docker compose pull` to get the latest migrator image.