### PR TITLE
Add various user- and beatmapset-related sanity checks to submission operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+osu-server-beatmap-submission.sln.DotSettings.user

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -287,6 +287,32 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestPutBeatmapSet_ExistingSet_CannotModifyIfRanked()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2000, '2411', 5)");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 5001, 5002, 5003, 5004, 5005 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 1000, 1)", new { beatmapId = beatmapId });
+
+            var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
+            request.Content = JsonContent.Create(new PutBeatmapSetRequest
+            {
+                BeatmapSetID = 1000,
+                BeatmapsToCreate = 3,
+                BeatmapsToKeep = [5001, 5003, 5005],
+            });
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotKeepBeatmapsThatWereNotPartOfTheSet()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -421,7 +447,6 @@ namespace osu.Server.BeatmapSubmission.Tests
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-
         [Fact]
         public async Task TestUploadFullPackage()
         {
@@ -496,6 +521,36 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestUploadFullPackage_FailsIfBeatmapRanked()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, 1)", new { beatmapId = beatmapId });
+
+            var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+
+            using var memoryStream = new MemoryStream();
+
+            using (new ZipWriter(memoryStream, BeatmapPackagePatcher.DEFAULT_ZIP_WRITER_OPTIONS))
+            {
+            }
+
+            content.Add(new StreamContent(memoryStream), "beatmapArchive", osz_filename);
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
         public async Task TestUploadFullPackage_FailsOnEmptyPackage()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -559,6 +614,35 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestPatchPackage_FailsIfBeatmapRanked()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, 1)", new { beatmapId = beatmapId });
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "filesChanged", osu_filename);
+            content.Add(new StringContent("Soleily - Renatus (Deif) [Platter].osu"), "filesDeleted");
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
         public async Task TestSubmitGuestDifficulty()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -590,6 +674,36 @@ namespace osu.Server.BeatmapSubmission.Tests
 
             var renamedBeatmap = await db.QuerySingleAsync<osu_beatmap>(@"SELECT * FROM `osu_beatmaps` WHERE `beatmap_id` = 557810");
             Assert.Equal("Platter 2", renamedBeatmap.version);
+        }
+
+        [Fact]
+        public async Task TestSubmitGuestDifficulty_FailsIfBeatmapRanked()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, 1)", new { beatmapId = beatmapId });
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, 1)");
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526/beatmaps/557810");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "beatmapContents", osu_filename);
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -47,6 +47,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
             request.Content = JsonContent.Create(new PutBeatmapSetRequest { BeatmapsToCreate = 15 });
@@ -108,10 +109,28 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestPutBeatmapSet_UserWithTooLowPlaycountCannotSubmit()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 3)");
+
+            var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
+            request.Content = JsonContent.Create(new PutBeatmapSetRequest { BeatmapsToCreate = 15 });
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Equal("Thanks for your contribution, but please play the game first!", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
         public async Task TestPutBeatmapSet_SilencedUserCanSubmitAfterSilenceExpires()
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
             await db.ExecuteAsync("INSERT INTO `osu_user_banhistory` (`user_id`, `ban_status`, `period`, `timestamp`) VALUES (2, 2, 86400, TIMESTAMPADD(DAY, -1, CURRENT_TIMESTAMP()))");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
@@ -129,6 +148,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
             request.Content = JsonContent.Create(new PutBeatmapSetRequest
@@ -149,6 +169,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
             request.Content = JsonContent.Create(new PutBeatmapSetRequest
@@ -168,6 +189,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -201,6 +223,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2000, '2411', 5)");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -226,6 +249,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -252,6 +276,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -276,6 +301,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (1000, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -302,6 +328,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         {
             using var db = DatabaseAccess.GetConnection();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+            await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
             request.Content = JsonContent.Create(new PutBeatmapSetRequest

--- a/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
@@ -35,6 +35,7 @@ namespace osu.Server.BeatmapSubmission.Tests
                 throw new InvalidOperationException("You have just attempted to run tests on production and wipe data. Rethink your life decisions.");
 
             db.Execute("TRUNCATE TABLE `osu_user_banhistory`");
+            db.Execute("TRUNCATE TABLE `osu_user_month_playcount`");
             db.Execute("TRUNCATE TABLE `phpbb_users`");
             db.Execute("TRUNCATE TABLE `osu_beatmaps`");
 

--- a/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/IntegrationTest.cs
@@ -34,6 +34,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             if (db.QueryFirstOrDefault<int?>("SELECT `count` FROM `osu_counts` WHERE name = 'is_production'") != null)
                 throw new InvalidOperationException("You have just attempted to run tests on production and wipe data. Rethink your life decisions.");
 
+            db.Execute("TRUNCATE TABLE `osu_user_banhistory`");
             db.Execute("TRUNCATE TABLE `phpbb_users`");
             db.Execute("TRUNCATE TABLE `osu_beatmaps`");
 

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -153,7 +153,6 @@ namespace osu.Server.BeatmapSubmission
             IFormFile beatmapArchive)
         {
             uint userId = User.GetUserId();
-            // TODO: do all of the due diligence checks
 
             using var db = DatabaseAccess.GetConnection();
 

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -52,7 +52,6 @@ namespace osu.Server.BeatmapSubmission
             if (userError != null)
                 return userError.ToActionResult();
 
-            // TODO: check difficulty limits (1 min, 128 max)
             // TODO: check playcount (`("SELECT sum(playcount) FROM osu_user_month_playcount WHERE user_id = $userId") < 5`)
             // TODO: clean up user's inactive maps
             // TODO: check remaining map quota
@@ -86,6 +85,12 @@ namespace osu.Server.BeatmapSubmission
 
             if (request.BeatmapsToKeep.Except(existingBeatmaps).Any())
                 return new ErrorResponse("One of the beatmaps to keep does not belong to the specified set.").ToActionResult();
+
+            uint totalBeatmapCount = (uint)request.BeatmapsToKeep.Length + request.BeatmapsToCreate;
+            if (totalBeatmapCount < 1)
+                return new ErrorResponse("The beatmap set must contain at least one beatmap.").ToActionResult();
+            if (totalBeatmapCount > 128)
+                return new ErrorResponse("The beatmap set cannot contain more than 128 beatmaps.").ToActionResult();
 
             foreach (uint beatmapId in existingBeatmaps.Except(request.BeatmapsToKeep))
                 await db.DeleteBeatmapAsync(beatmapId, transaction);

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -53,6 +53,17 @@ namespace osu.Server.BeatmapSubmission
             return ban != null && ban.period != 0 && ban.EndTime > DateTimeOffset.Now;
         }
 
+        public static async Task<ulong> GetUserMonthlyPlaycountAsync(this MySqlConnection db, uint userId, MySqlTransaction? transaction = null)
+        {
+            return await db.QuerySingleAsync<ulong?>(
+                @"SELECT SUM(`playcount`) FROM `osu_user_month_playcount` WHERE `user_id` = @user_id",
+                new
+                {
+                    user_id = userId,
+                },
+                transaction) ?? 0;
+        }
+
         public static Task<osu_beatmapset?> GetBeatmapSetAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)
         {
             return db.QuerySingleOrDefaultAsync<osu_beatmapset?>(@"SELECT * FROM `osu_beatmapsets` WHERE `beatmapset_id` = @beatmapSetId",

--- a/osu.Server.BeatmapSubmission/InvariantExceptionFilter.cs
+++ b/osu.Server.BeatmapSubmission/InvariantExceptionFilter.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+using osu.Server.BeatmapSubmission.Models;
+
+namespace osu.Server.BeatmapSubmission
+{
+    public class InvariantExceptionFilter : IExceptionFilter
+    {
+        public void OnException(ExceptionContext context)
+        {
+            if (context.Exception is InvariantException invariantException)
+                context.Result = invariantException.ToResponseObject().ToActionResult();
+        }
+    }
+}

--- a/osu.Server.BeatmapSubmission/Models/API/Requests/PutBeatmapSetRequest.cs
+++ b/osu.Server.BeatmapSubmission/Models/API/Requests/PutBeatmapSetRequest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace osu.Server.BeatmapSubmission.Models.API.Requests
@@ -22,7 +21,6 @@ namespace osu.Server.BeatmapSubmission.Models.API.Requests
         /// </summary>
         /// <example>12</example>
         [JsonPropertyName("beatmaps_to_create")]
-        [Range(1, 128)]
         public uint BeatmapsToCreate { get; set; }
 
         /// <summary>

--- a/osu.Server.BeatmapSubmission/Models/API/Responses/ErrorResponse.cs
+++ b/osu.Server.BeatmapSubmission/Models/API/Responses/ErrorResponse.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace osu.Server.BeatmapSubmission.Models.API.Responses
+{
+    /// <summary>
+    /// Response type issued in case of an error that is directly presentable to the user.
+    /// </summary>
+    public class ErrorResponse
+    {
+        [JsonPropertyName("error")]
+        public string Error { get; }
+
+        public ErrorResponse(string error)
+        {
+            Error = error;
+        }
+
+        public IActionResult ToActionResult() => new UnprocessableEntityObjectResult(this);
+    }
+}

--- a/osu.Server.BeatmapSubmission/Models/Database/osu_user_banhistory.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/osu_user_banhistory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Server.BeatmapSubmission.Models.Database
+{
+    public class osu_user_banhistory
+    {
+        public uint ban_id { get; set; }
+        public uint user_id { get; set; }
+        public uint period { get; set; }
+        public DateTimeOffset timestamp { get; set; }
+
+        /// <seealso href="https://github.com/ppy/osu-web/blob/65ca10d9b137009c5a33876b4caef3453dfb0bc2/app/Models/UserAccountHistory.php#L113-L116"/>
+        public DateTimeOffset EndTime => timestamp.AddSeconds(period);
+    }
+}

--- a/osu.Server.BeatmapSubmission/Models/InvariantException.cs
+++ b/osu.Server.BeatmapSubmission/Models/InvariantException.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Server.BeatmapSubmission.Models.API.Responses;
+
+namespace osu.Server.BeatmapSubmission.Models
+{
+    /// <summary>
+    /// Exceptions of this type are violations of various invariants enforced by this server,
+    /// and their messages are assumed to be directly presentable to the user.
+    /// </summary>
+    public class InvariantException : Exception
+    {
+        public InvariantException(string message)
+            : base(message)
+        {
+        }
+
+        public ErrorResponse ToResponseObject() => new ErrorResponse(Message);
+    }
+}

--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -16,7 +16,10 @@ namespace osu.Server.BeatmapSubmission
 
             // Add services to the container.
             builder.Services.AddAuthorization();
-            builder.Services.AddControllers();
+            builder.Services.AddControllers(options =>
+            {
+                options.Filters.Add<InvariantExceptionFilter>();
+            });
             builder.Services.AddLogging(logging =>
             {
                 logging.ClearProviders();

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
@@ -88,10 +88,8 @@ namespace osu.Server.BeatmapSubmission.Services
 
         private static osu_beatmapset constructDatabaseRowForBeatmapset(uint beatmapSetId, ArchiveReader archiveReader, BeatmapContent[] beatmaps)
         {
-            // TODO: currently all exceptions thrown here will be 500s, they should be 429s
-
             if (beatmaps.Length == 0)
-                throw new InvalidOperationException("The uploaded beatmap set must have at least one difficulty.");
+                throw new InvariantException("The uploaded beatmap set must have at least one difficulty.");
 
             float firstBeatLength = (float)beatmaps.First().Beatmap.GetMostCommonBeatLength();
 
@@ -143,7 +141,7 @@ namespace osu.Server.BeatmapSubmission.Services
         {
             T[] distinctValues = beatmapContents.Select(accessor).Distinct().ToArray();
             if (distinctValues.Length != 1)
-                throw new InvalidOperationException($"The uploaded beatmap set's individual difficulties have inconsistent {valueName}. Please unify {valueName} before re-submitting.");
+                throw new InvariantException($"The uploaded beatmap set's individual difficulties have inconsistent {valueName}. Please unify {valueName} before re-submitting.");
 
             return distinctValues.Single();
         }


### PR DESCRIPTION
Not everything is covered yet, just splitting this off as it has grown large enough to PR before continuing further.

## What is covered

- user status checks (silences / restrictions)
- required minimum playcount to create a beatmapset
- user upload quota
- online status-related checks (no updating of anything ranked/loved/etc., no updating of anything graved if no quota left to revive)
- beatmap difficulty count limits

## What is left to implement (and is coming next / later)

- skipping upload if nothing actually changed
- checking that all online IDs in the `.osu`s are valid
- checking that all the `.osu`s that should be in the package are in it, and that there are no more
- prevent uploading files with potentially harmful extensions
- implementation of beatmap revival start-to-end