### PR TITLE
Add various sanity checks concerning contents of beatmap package

### DIFF
--- a/.idea/.idea.osu-server-beatmap-submission/.idea/sqldialects.xml
+++ b/.idea/.idea.osu-server-beatmap-submission/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="MySQL" />
+  </component>
+</project>

--- a/UseLocalOsu.ps1
+++ b/UseLocalOsu.ps1
@@ -1,0 +1,24 @@
+# Run this script to use a local copy of osu rather than fetching it from nuget.
+# It expects the osu directory to be at the same level as the osu-server-beatmap-submission directory
+
+
+$CSPROJ="osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj"
+$SLN="osu-server-beatmap-submission.sln"
+
+$DEPENDENCIES=@(
+    "..\osu\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj"
+    "..\osu\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj"
+    "..\osu\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj"
+    "..\osu\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj"
+    "..\osu\osu.Game\osu.Game.csproj"
+)
+
+
+dotnet remove $CSPROJ package ppy.osu.Game
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Osu
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Taiko
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Catch
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Mania
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES

--- a/UseLocalOsu.sh
+++ b/UseLocalOsu.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Run this script to use a local copy of osu rather than fetching it from nuget.
+# It expects the osu directory to be at the same level as the osu-server-beatmap-submission directory
+
+
+CSPROJ="osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj"
+SLN="osu-server-beatmap-submission.sln"
+
+DEPENDENCIES="../osu/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+    ../osu/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+    ../osu/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+    ../osu/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+    ../osu/osu.Game/osu.Game.csproj"
+
+
+dotnet remove $CSPROJ package ppy.osu.Game
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Osu
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Taiko
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Catch
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Mania
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -50,7 +50,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NewSet()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
@@ -77,7 +77,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_RestrictedUserCannotSubmit()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`, `user_warnings`) VALUES (2, 'test', 'JP', '', '', '', '', 1)");
 
             var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets");
@@ -93,7 +93,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_SilencedUserCannotSubmit()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync(
                 """
@@ -116,7 +116,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_UserWithTooLowPlaycountCannotSubmit()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 3)");
 
@@ -133,7 +133,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_SilencedUserCanSubmitAfterSilenceExpires()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
             await db.ExecuteAsync("INSERT INTO `osu_user_banhistory` (`user_id`, `ban_status`, `period`, `timestamp`) VALUES (2, 2, 86400, TIMESTAMPADD(DAY, -1, CURRENT_TIMESTAMP()))");
@@ -151,7 +151,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NewSet_CannotSpecifyBeatmapsToKeep()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
@@ -172,7 +172,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NewSet_CannotExceedMaxBeatmapLimit()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
@@ -192,7 +192,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NewSet_BeatmapSetQuotaExceeded()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
@@ -212,7 +212,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NewSet_InactiveBeatmapsArePurged()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2, '2411', 5)");
 
@@ -233,7 +233,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -267,7 +267,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotModifyDeletedSet()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -293,7 +293,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotModifyIfNotOwner()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2000, '2411', 5)");
 
@@ -319,7 +319,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotModifyIfRanked()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (2000, '2411', 5)");
 
@@ -345,7 +345,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotKeepBeatmapsThatWereNotPartOfTheSet()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -372,7 +372,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotDeleteAllBeatmaps()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -397,7 +397,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_CannotExceedMaxBeatmapLimit()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -424,7 +424,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_ExistingSet_BeatmapSetQuotaExceeded()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`, `osu_subscriber`) VALUES (1000, 'test', 'JP', '', '', '', '', 1)");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -460,7 +460,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPutBeatmapSet_NonexistentSet()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync("INSERT INTO `osu_user_month_playcount` (`user_id`, `year_month`, `playcount`) VALUES (1000, '2411', 5)");
 
@@ -480,7 +480,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -553,7 +553,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_DeletedBeatmapsDoNotInterfere()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -580,7 +580,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsIfBeatmapDeleted()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`, `deleted_at`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP, NOW())");
@@ -604,7 +604,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsIfBeatmapRanked()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
@@ -634,7 +634,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsIfBeatmapQuotaExceeded()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             for (int i = 0; i < 4; ++i)
@@ -662,7 +662,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsOnEmptyPackage()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -692,7 +692,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsOnPackageWithSuspiciousFile()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -721,7 +721,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsIfBeatmapsDoNotHaveCorrectSetIDsInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (999999, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -746,7 +746,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestUploadFullPackage_FailsIfBeatmapsDoNotHaveCorrectIDsInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -775,7 +775,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [InlineData("b\\..\\..\\..\\suspicious")]
         public async Task TestUploadFullPackage_PathTraversalAttackFails(string suspiciousFilename)
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -809,7 +809,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -842,7 +842,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_AddStoryboard()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -879,7 +879,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsIfBeatmapDeleted()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`, `deleted_at`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP, NOW())");
@@ -908,7 +908,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsIfBeatmapRanked()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
@@ -937,7 +937,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsIfQuotaExceeded()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             for (int i = 0; i < 4; ++i)
@@ -970,7 +970,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsOnSuspiciousFileTypes()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -999,7 +999,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsIfBeatmapDoesNotHaveCorrectSetIDInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (999999, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1029,7 +1029,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestPatchPackage_FailsIfBeatmapDoesNotHaveCorrectIDInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1063,7 +1063,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [InlineData("b\\..\\..\\..\\suspicious")]
         public async Task TestPatchPackage_PathTraversalFails(string suspiciousPath)
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1089,7 +1089,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1123,7 +1123,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsIfBeatmapDeleted()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`, `deleted_at`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP, NOW())");
@@ -1153,7 +1153,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsIfBeatmapRanked()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', 1, 0, 1, CURRENT_TIMESTAMP)");
@@ -1183,7 +1183,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsIfBeatmapInGraveyard()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -2, 0, 1, CURRENT_TIMESTAMP)");
@@ -1214,7 +1214,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsWhenDoneByAnotherUser()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (3000, 'test', 'JP', '', '', '', '')");
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
 
@@ -1243,7 +1243,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsOnSuspiciousFileTypes()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1274,7 +1274,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsWhenTryingToOverwriteACompletelyDifferentFile()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1305,7 +1305,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsIfBeatmapDoesNotHaveCorrectSetIDInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (999999, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1336,7 +1336,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [Fact]
         public async Task TestSubmitGuestDifficulty_FailsIfBeatmapDoesNotHaveCorrectIDInside()
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
@@ -1373,7 +1373,7 @@ namespace osu.Server.BeatmapSubmission.Tests
         [InlineData("b\\..\\..\\..\\suspicious")]
         public async Task TestSubmitGuestDifficulty_PathTraversalFails(string suspiciousPath)
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
             await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
 
             await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -715,7 +715,7 @@ namespace osu.Server.BeatmapSubmission.Tests
 
             var response = await Client.SendAsync(request);
             Assert.False(response.IsSuccessStatusCode);
-            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+            Assert.Contains("Beatmap contains an unsupported file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         [Fact]
@@ -956,7 +956,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             var response = await Client.SendAsync(request);
             Assert.False(response.IsSuccessStatusCode);
             Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+            Assert.Contains("Beatmap contains an unsupported file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         [Fact]
@@ -1231,7 +1231,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             var response = await Client.SendAsync(request);
             Assert.False(response.IsSuccessStatusCode);
             Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+            Assert.Contains("Beatmap contains an unsupported file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         [Fact]

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -15,6 +15,7 @@ using osu.Server.BeatmapSubmission.Models.Database;
 using osu.Server.BeatmapSubmission.Services;
 using osu.Server.BeatmapSubmission.Tests.Resources;
 using osu.Server.QueueProcessor;
+using SharpCompress.Writers;
 using SharpCompress.Writers.Zip;
 
 namespace osu.Server.BeatmapSubmission.Tests
@@ -609,6 +610,35 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestUploadFullPackage_FailsOnPackageWithSuspiciousFile()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+
+            using var memoryStream = new MemoryStream();
+
+            using (var zipWriter = new ZipWriter(memoryStream, BeatmapPackagePatcher.DEFAULT_ZIP_WRITER_OPTIONS))
+                zipWriter.Write("bad.dll", new MemoryStream("i am a bad file >:)"u8.ToArray()));
+
+            content.Add(new StreamContent(memoryStream), "beatmapArchive", osz_filename);
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
         public async Task TestPatchPackage()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -701,6 +731,35 @@ namespace osu.Server.BeatmapSubmission.Tests
             Assert.False(response.IsSuccessStatusCode);
             Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
             Assert.Equal("Beatmap is in the graveyard and you don't have enough remaining upload quota to resurrect it.", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
+        public async Task TestPatchPackage_FailsOnSuspiciousFileTypes()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "filesChanged", "suspicious.PY");
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         [Fact]
@@ -825,6 +884,37 @@ namespace osu.Server.BeatmapSubmission.Tests
             var response = await Client.SendAsync(request);
             Assert.False(response.IsSuccessStatusCode);
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task TestSubmitGuestDifficulty_FailsOnSuspiciousFileTypes()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526/beatmaps/557810");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "beatmapContents", "suspicious.doc");
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         public override void Dispose()

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -917,6 +917,37 @@ namespace osu.Server.BeatmapSubmission.Tests
             Assert.Contains("Beatmap contains a dangerous file type", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
+        [Fact]
+        public async Task TestSubmitGuestDifficulty_FailsWhenTryingToOverwriteACompletelyDifferentFile()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526/beatmaps/557810");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "beatmapContents", "Soleily - Renatus (MMzz) [Futsuu].osu"); // uses filename of an existing, completely different file
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Chosen filename conflicts with another existing file", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
         public override void Dispose()
         {
             base.Dispose();

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -3,9 +3,11 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using Dapper;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using osu.Framework.Extensions;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Server.BeatmapSubmission.Authentication;
@@ -664,6 +666,31 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestUploadFullPackage_FailsIfBeatmapsDoNotHaveCorrectIDsInside()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 1 }) // last ID will not match
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            var request = new HttpRequestMessage(HttpMethod.Put, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var stream = TestResources.GetResource(osz_filename)!;
+            content.Add(new StreamContent(stream), "beatmapArchive", osz_filename);
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Beatmap has invalid ID inside", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
         public async Task TestPatchPackage()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -818,6 +845,36 @@ namespace osu.Server.BeatmapSubmission.Tests
         }
 
         [Fact]
+        public async Task TestPatchPackage_FailsIfBeatmapDoesNotHaveCorrectIDInside()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 1, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            content.Add(new StreamContent(osuFileStream), "filesChanged", osu_filename);
+            content.Add(new StringContent("Soleily - Renatus (Deif) [Platter].osu"), "filesDeleted");
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Beatmap has invalid ID inside", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
         public async Task TestSubmitGuestDifficulty()
         {
             using var db = DatabaseAccess.GetConnection();
@@ -828,7 +885,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -862,7 +919,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, 1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, 1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, 1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -892,7 +949,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -2)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -2)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -2, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -922,7 +979,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -952,7 +1009,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -983,7 +1040,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 241526, -1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -1014,7 +1071,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
                 await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 999999, -1)", new { beatmapId = beatmapId });
 
-            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (557810, 2000, 999999, -1)");
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 999999, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
 
             using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "999999")))
             using (var srcStream = TestResources.GetResource(osz_filename)!)
@@ -1032,6 +1089,39 @@ namespace osu.Server.BeatmapSubmission.Tests
             Assert.False(response.IsSuccessStatusCode);
             Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
             Assert.Contains("Beatmap has invalid beatmap set ID inside", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+        }
+
+        [Fact]
+        public async Task TestSubmitGuestDifficulty_FailsIfBeatmapDoesNotHaveCorrectIDInside()
+        {
+            using var db = DatabaseAccess.GetConnection();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2000, 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`, `filename`) VALUES (557810, 2000, 241526, -1, 'Soleily - Renatus (Deif) [Platter].osu')");
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526/beatmaps/557810");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            using var osuFileStream = TestResources.GetResource(osu_filename)!;
+            string osuFileContents = Encoding.UTF8.GetString(await osuFileStream.ReadAllBytesToArrayAsync());
+            osuFileContents = osuFileContents.Replace("BeatmapID:557810", "BeatmapID:1");
+            content.Add(new ByteArrayContent(Encoding.UTF8.GetBytes(osuFileContents)), "beatmapContents", osu_filename);
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "2000");
+
+            var response = await Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+            Assert.Contains("Beatmap has invalid ID inside", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
         public override void Dispose()

--- a/osu.Server.BeatmapSubmission.Tests/osu.Server.BeatmapSubmission.Tests.csproj
+++ b/osu.Server.BeatmapSubmission.Tests/osu.Server.BeatmapSubmission.Tests.csproj
@@ -10,12 +10,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/osu.Server.BeatmapSubmission/Authentication/OsuWebSharedJwtBearerOptions.cs
+++ b/osu.Server.BeatmapSubmission/Authentication/OsuWebSharedJwtBearerOptions.cs
@@ -46,7 +46,7 @@ namespace osu.Server.BeatmapSubmission.Authentication
                     var jwtToken = (JsonWebToken)context.SecurityToken;
                     int tokenUserId = int.Parse(jwtToken.Subject);
 
-                    using (var db = DatabaseAccess.GetConnection())
+                    using (var db = await DatabaseAccess.GetConnectionAsync())
                     {
                         // check expiry/revocation against database
                         int? userId = await db.QueryFirstOrDefaultAsync<int?>("SELECT `user_id` FROM `oauth_access_tokens` WHERE `revoked` = false AND `expires_at` > now() AND `id` = @id",

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -275,7 +275,7 @@ namespace osu.Server.BeatmapSubmission
             if (beatmapSet.approved == BeatmapOnlineStatus.Graveyard)
                 return new ErrorResponse("The beatmap set is in the graveyard. Please ask the set owner to revive it first.").ToActionResult();
 
-            var archiveStream = await patcher.PatchBeatmapAsync(beatmapSetId, beatmapId, beatmapContents);
+            var archiveStream = await patcher.PatchBeatmapAsync(beatmapSetId, beatmap, beatmapContents);
             // TODO: double-check that the patched archive is actually meaningfully different from the previous one
             await updateBeatmapSetFromArchiveAsync(beatmapSetId, archiveStream, db);
             return NoContent();
@@ -307,22 +307,30 @@ namespace osu.Server.BeatmapSubmission
             var parseResult = BeatmapPackageParser.Parse(beatmapSetId, archiveReader);
             using var transaction = await db.BeginTransactionAsync();
 
-            // TODO: ensure these actually belong to the beatmap set
-            foreach (var beatmapRow in parseResult.Beatmaps)
-                await db.UpdateBeatmapAsync(beatmapRow, transaction);
-
-            await db.UpdateBeatmapSetAsync(parseResult.BeatmapSet, transaction);
+            HashSet<uint> beatmapIds = (await db.GetBeatmapIdsInSetAsync(beatmapSetId, transaction)).ToHashSet();
 
             foreach (var versionedFile in parseResult.Files)
                 versionedFile.VersionFile.file_id = await db.InsertBeatmapsetFileAsync(versionedFile.File, transaction);
 
             ulong versionId = await db.CreateBeatmapsetVersionAsync(beatmapSetId, transaction);
 
-            foreach (var versionedFile in parseResult.Files)
+            foreach (var packageFile in parseResult.Files)
             {
-                versionedFile.VersionFile.version_id = versionId;
-                await db.InsertBeatmapsetVersionFileAsync(versionedFile.VersionFile, transaction);
+                packageFile.VersionFile.version_id = versionId;
+                await db.InsertBeatmapsetVersionFileAsync(packageFile.VersionFile, transaction);
+
+                if (packageFile.BeatmapContent is BeatmapContent content)
+                {
+                    if (!beatmapIds.Remove((uint)content.Beatmap.BeatmapInfo.OnlineID))
+                        throw new InvariantException($"Beatmap has invalid ID inside ({packageFile.VersionFile.filename}).");
+
+                    await db.UpdateBeatmapAsync(content.GetDatabaseRow(), transaction);
+                }
+
+                // TODO: check if there are any beatmap IDs left and throw if so
             }
+
+            await db.UpdateBeatmapSetAsync(parseResult.BeatmapSet, transaction);
 
             await transaction.CommitAsync();
             // TODO: the ACID implications on this happening post-commit are... interesting... not sure anything can be done better?
@@ -350,7 +358,7 @@ namespace osu.Server.BeatmapSubmission
         {
             using var db = DatabaseAccess.GetConnection();
 
-            (beatmapset_version version, VersionedFile[] files)? versionInfo = await db.GetBeatmapsetVersionAsync(beatmapSetId, versionId);
+            (beatmapset_version version, PackageFile[] files)? versionInfo = await db.GetBeatmapsetVersionAsync(beatmapSetId, versionId);
 
             if (versionInfo == null)
                 return NotFound();

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -228,6 +228,9 @@ namespace osu.Server.BeatmapSubmission
                 // TODO: revive the map otherwise
             }
 
+            if (filesChanged.Any(f => SanityCheckHelpers.IncursPathTraversalRisk(f.FileName)))
+                return new ErrorResponse("Invalid filename detected").ToActionResult();
+
             var beatmapStream = await patcher.PatchBeatmapSetAsync(beatmapSetId, filesChanged, filesDeleted);
             // TODO: double-check that the patched archive is actually meaningfully different from the previous one
             // TODO: ensure that after patching, all the `.osu`s that should be in the `.osz` ARE in the `.osz`, and ensure there are no EXTRA `.osu`s
@@ -274,6 +277,9 @@ namespace osu.Server.BeatmapSubmission
 
             if (beatmapSet.approved == BeatmapOnlineStatus.Graveyard)
                 return new ErrorResponse("The beatmap set is in the graveyard. Please ask the set owner to revive it first.").ToActionResult();
+
+            if (SanityCheckHelpers.IncursPathTraversalRisk(beatmapContents.FileName))
+                return new ErrorResponse("Invalid filename detected").ToActionResult();
 
             var archiveStream = await patcher.PatchBeatmapAsync(beatmapSetId, beatmap, beatmapContents);
             // TODO: double-check that the patched archive is actually meaningfully different from the previous one

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -326,9 +326,10 @@ namespace osu.Server.BeatmapSubmission
 
                     await db.UpdateBeatmapAsync(content.GetDatabaseRow(), transaction);
                 }
-
-                // TODO: check if there are any beatmap IDs left and throw if so
             }
+
+            if (beatmapIds.Count > 0)
+                throw new InvariantException($"Beatmap package is missing .osu files for beatmaps with IDs: {string.Join(", ", beatmapIds)}");
 
             await db.UpdateBeatmapSetAsync(parseResult.BeatmapSet, transaction);
 

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -48,7 +48,7 @@ namespace osu.Server.BeatmapSubmission
         {
             uint userId = User.GetUserId();
 
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
 
             ErrorResponse? userError = await checkUserAccountStanding(db, userId);
             if (userError != null)
@@ -154,7 +154,7 @@ namespace osu.Server.BeatmapSubmission
         {
             uint userId = User.GetUserId();
 
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
 
             ErrorResponse? userError = await checkUserAccountStanding(db, userId);
             if (userError != null)
@@ -204,7 +204,7 @@ namespace osu.Server.BeatmapSubmission
             [FromForm] string[] filesDeleted)
         {
             uint userId = User.GetUserId();
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
 
             ErrorResponse? userError = await checkUserAccountStanding(db, userId);
             if (userError != null)
@@ -257,7 +257,7 @@ namespace osu.Server.BeatmapSubmission
             IFormFile beatmapContents)
         {
             uint userId = User.GetUserId();
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
 
             ErrorResponse? userError = await checkUserAccountStanding(db, userId);
             if (userError != null)
@@ -363,7 +363,7 @@ namespace osu.Server.BeatmapSubmission
             [FromRoute] uint beatmapSetId,
             [FromRoute] uint versionId)
         {
-            using var db = DatabaseAccess.GetConnection();
+            using var db = await DatabaseAccess.GetConnectionAsync();
 
             (beatmapset_version version, PackageFile[] files)? versionInfo = await db.GetBeatmapsetVersionAsync(beatmapSetId, versionId);
 

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -248,7 +248,7 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
-        public static async Task<(beatmapset_version, VersionedFile[])?> GetBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, ulong versionId, MySqlTransaction? transaction = null)
+        public static async Task<(beatmapset_version, PackageFile[])?> GetBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, ulong versionId, MySqlTransaction? transaction = null)
         {
             var version = await db.QuerySingleOrDefaultAsync<beatmapset_version?>(
                 "SELECT * FROM `beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id AND `version_id` = @version_id",
@@ -261,13 +261,13 @@ namespace osu.Server.BeatmapSubmission
             if (version == null)
                 return null;
 
-            VersionedFile[] files = (await db.QueryAsync(
+            PackageFile[] files = (await db.QueryAsync(
                 """
                 SELECT `f`.`file_id`, `f`.`sha2_hash`, `f`.`file_size`, `vf`.`file_id` AS `versioned_file_id`, `vf`.`version_id`, `vf`.`filename` FROM `beatmapset_files` `f`
                 JOIN `beatmapset_version_files` `vf` ON `f`.`file_id` = `vf`.`file_id`
                 WHERE `vf`.`version_id` = @version_id
                 """,
-                (beatmapset_file file, beatmapset_version_file versionFile) => new VersionedFile(file, versionFile),
+                (beatmapset_file file, beatmapset_version_file versionFile) => new PackageFile(file, versionFile),
                 new
                 {
                     version_id = version.version_id

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -125,7 +125,7 @@ namespace osu.Server.BeatmapSubmission
 
         public static Task<IEnumerable<uint>> GetBeatmapIdsInSetAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)
         {
-            return db.QueryAsync<uint>(@"SELECT `beatmap_id` FROM `osu_beatmaps` WHERE `beatmapset_id` = @beatmapSetId",
+            return db.QueryAsync<uint>(@"SELECT `beatmap_id` FROM `osu_beatmaps` WHERE `beatmapset_id` = @beatmapSetId AND `deleted_at` IS NULL",
                 new
                 {
                     beatmapSetId = beatmapSetId,

--- a/osu.Server.BeatmapSubmission/Models/PackageFile.cs
+++ b/osu.Server.BeatmapSubmission/Models/PackageFile.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Server.BeatmapSubmission.Models.Database;
+using osu.Server.BeatmapSubmission.Services;
 
 namespace osu.Server.BeatmapSubmission.Models
 {
-    public readonly struct VersionedFile(beatmapset_file file, beatmapset_version_file versionFile)
+    public readonly struct PackageFile(beatmapset_file file, beatmapset_version_file versionFile, BeatmapContent? beatmapContent = null)
     {
         public beatmapset_file File { get; } = file;
         public beatmapset_version_file VersionFile { get; } = versionFile;
+        public BeatmapContent? BeatmapContent { get; } = beatmapContent;
     }
 }

--- a/osu.Server.BeatmapSubmission/SanityCheckHelpers.cs
+++ b/osu.Server.BeatmapSubmission/SanityCheckHelpers.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.BeatmapSubmission
+{
+    public static class SanityCheckHelpers
+    {
+        public static bool IncursPathTraversalRisk(string path)
+            => path.Contains("../", StringComparison.Ordinal) || path.Contains("..\\", StringComparison.Ordinal) || Path.IsPathRooted(path);
+    }
+}

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
@@ -18,7 +18,7 @@ namespace osu.Server.BeatmapSubmission.Services
 {
     public static class BeatmapPackageParser
     {
-        public static readonly HashSet<string> VALID_EXTENSIONS = new HashSet<string>([..SupportedExtensions.ALL_EXTENSIONS, @".osu"], StringComparer.OrdinalIgnoreCase);
+        public static readonly HashSet<string> VALID_EXTENSIONS = new HashSet<string>([..SupportedExtensions.ALL_EXTENSIONS, @".osu", @".osb"], StringComparer.OrdinalIgnoreCase);
 
         public static BeatmapPackageParseResult Parse(uint beatmapSetId, ArchiveReader archiveReader)
         {

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
@@ -18,6 +18,12 @@ namespace osu.Server.BeatmapSubmission.Services
 {
     public static class BeatmapPackageParser
     {
+        public static readonly HashSet<string> INVALID_EXTENSIONS = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".exe", ".cmd", ".bat", ".sh", ".scr", ".doc", ".docx", ".docm", ".hta", ".htm", ".html", ".js", ".jar", ".vbs", ".vb", ".pdf", ".sfx", ".dll", ".py",
+            ".cer", ".apk", ".bin", ".msi", ".wsf", ".xls", ".xlsx", ".xlsm", ".ppt", ".pptx", ".pptm",
+        };
+
         public static BeatmapPackageParseResult Parse(uint beatmapSetId, ArchiveReader archiveReader)
         {
             string[] filenames = archiveReader.Filenames.ToArray();
@@ -28,6 +34,10 @@ namespace osu.Server.BeatmapSubmission.Services
 
             foreach (string filename in filenames)
             {
+                string extension = Path.GetExtension(filename);
+                if (INVALID_EXTENSIONS.Contains(extension))
+                    throw new InvariantException($"Beatmap contains a dangerous file type ({extension})");
+
                 var stream = archiveReader.GetStream(filename);
                 files.Add(new VersionedFile(
                     new beatmapset_file

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackageParser.cs
@@ -36,6 +36,9 @@ namespace osu.Server.BeatmapSubmission.Services
                 if (INVALID_EXTENSIONS.Contains(extension))
                     throw new InvariantException($"Beatmap contains a dangerous file type ({extension})");
 
+                if (SanityCheckHelpers.IncursPathTraversalRisk(filename))
+                    throw new InvariantException("Invalid filename detected");
+
                 var stream = archiveReader.GetStream(filename);
                 BeatmapContent? beatmapContent = null;
 

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackagePatcher.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackagePatcher.cs
@@ -5,6 +5,7 @@ using osu.Framework.Extensions;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
+using osu.Server.BeatmapSubmission.Models;
 using SharpCompress.Common;
 using SharpCompress.Writers;
 using SharpCompress.Writers.Zip;
@@ -97,11 +98,15 @@ namespace osu.Server.BeatmapSubmission.Services
             }
 
             if (existingBeatmapFilename == null)
-                throw new InvalidOperationException("Could not find the old .osu file for the beatmap being modified!");
+                throw new InvalidOperationException("Could not find the old .osu file for the beatmap being modified.");
 
             File.Delete(existingBeatmapFilename);
 
-            using (var file = File.OpenWrite(Path.Combine(tempDirectory.FullName, beatmapContents.FileName)))
+            string targetFilename = Path.Combine(tempDirectory.FullName, beatmapContents.FileName);
+            if (File.Exists(targetFilename))
+                throw new InvariantException($"Chosen filename conflicts with another existing file ({beatmapContents.FileName}).");
+
+            using (var file = File.OpenWrite(targetFilename))
             {
                 using var beatmapStream = beatmapContents.OpenReadStream();
                 await beatmapStream.CopyToAsync(file);

--- a/osu.Server.BeatmapSubmission/Services/BeatmapPackagePatcher.cs
+++ b/osu.Server.BeatmapSubmission/Services/BeatmapPackagePatcher.cs
@@ -66,7 +66,6 @@ namespace osu.Server.BeatmapSubmission.Services
             {
                 foreach (string file in Directory.EnumerateFiles(tempDirectory.FullName, "*", SearchOption.AllDirectories))
                 {
-                    // TODO: screen for dodgy file types and refuse to package if anything is suspicious
                     using var stream = File.OpenRead(file);
                     writer.Write(Path.GetRelativePath(tempDirectory.FullName, file), stream);
                 }

--- a/osu.Server.BeatmapSubmission/Services/IBeatmapStorage.cs
+++ b/osu.Server.BeatmapSubmission/Services/IBeatmapStorage.cs
@@ -14,6 +14,6 @@ namespace osu.Server.BeatmapSubmission.Services
 
         Task ExtractBeatmapSetAsync(uint beatmapSetId, string targetDirectory);
 
-        Task<Stream> PackageBeatmapSetFilesAsync(IEnumerable<VersionedFile> files);
+        Task<Stream> PackageBeatmapSetFilesAsync(IEnumerable<PackageFile> files);
     }
 }

--- a/osu.Server.BeatmapSubmission/Services/LocalBeatmapStorage.cs
+++ b/osu.Server.BeatmapSubmission/Services/LocalBeatmapStorage.cs
@@ -82,7 +82,7 @@ namespace osu.Server.BeatmapSubmission.Services
             }
         }
 
-        public Task<Stream> PackageBeatmapSetFilesAsync(IEnumerable<VersionedFile> files) => Task.Run<Stream>(() =>
+        public Task<Stream> PackageBeatmapSetFilesAsync(IEnumerable<PackageFile> files) => Task.Run<Stream>(() =>
         {
             var memoryStream = new MemoryStream();
 

--- a/osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj
+++ b/osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj
@@ -12,19 +12,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
         <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10"/>
-        <PackageReference Include="ppy.osu.Game" Version="2024.1115.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1115.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1115.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1115.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1115.1" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="7.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.1130.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1130.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1130.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1130.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1130.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-server-beatmap-submission/pull/4 for mergeability
- [x] Depends on https://github.com/ppy/osu/pull/30915
- [x] Depends on game package w/ above pull

Covers:

- checking that all online IDs in the `.osu`s are valid
- checking that all the `.osu`s that should be in the package are in it, and that there are no more
- prevent uploading files with potentially harmful extensions
- prevent guests from overwriting files that are not their difficulty

Skipping upload if nothing actually changed is going to likely be delayed until I address another item from https://github.com/ppy/osu-server-beatmap-submission/issues/2, namely "Use beatmap versioning tables for listing package contents rather than extracting the package" - that listing capability is going to come useful for that check.