### PR TITLE
Optimise package-related operations

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -135,11 +135,13 @@ namespace osu.Server.BeatmapSubmission
             if (beatmapRevived)
                 await legacyIO.BroadcastReviveBeatmapSetEventAsync(beatmapSetId.Value);
 
+            (beatmapset_version version, PackageFile[] files)? latestVersion = await db.GetLatestBeatmapsetVersionAsync(beatmapSetId.Value);
+
             return Ok(new PutBeatmapSetResponse
             {
                 BeatmapSetId = beatmapSetId.Value,
                 BeatmapIds = beatmapIds,
-                Files = beatmapStorage.ListBeatmapSetFiles(beatmapSetId.Value),
+                Files = latestVersion?.files.Select(f => new BeatmapSetFile(f.VersionFile.filename, BitConverter.ToString(f.File.sha2_hash).Replace("-", ""))).ToArray() ?? [],
             });
         }
 

--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -194,6 +194,8 @@ namespace osu.Server.BeatmapSubmission
 
             if (newSubmission)
                 await legacyIO.BroadcastNewBeatmapSetEventAsync(beatmapSetId);
+            else
+                await legacyIO.BroadcastUpdateBeatmapSetEventAsync(beatmapSetId, userId);
 
             return NoContent();
         }
@@ -247,6 +249,8 @@ namespace osu.Server.BeatmapSubmission
             // TODO: double-check that the patched archive is actually meaningfully different from the previous one
             // TODO: ensure that after patching, all the `.osu`s that should be in the `.osz` ARE in the `.osz`, and ensure there are no EXTRA `.osu`s
             await updateBeatmapSetFromArchiveAsync(beatmapSetId, beatmapStream, db);
+
+            await legacyIO.BroadcastUpdateBeatmapSetEventAsync(beatmapSetId, userId);
             return NoContent();
         }
 
@@ -299,6 +303,8 @@ namespace osu.Server.BeatmapSubmission
             var archiveStream = await patcher.PatchBeatmapAsync(beatmapSetId, beatmap, beatmapContents);
             // TODO: double-check that the patched archive is actually meaningfully different from the previous one
             await updateBeatmapSetFromArchiveAsync(beatmapSetId, archiveStream, db);
+
+            await legacyIO.BroadcastUpdateBeatmapSetEventAsync(beatmapSetId, userId);
             return NoContent();
         }
 

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -276,15 +276,20 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
-        public static async Task<beatmapset_version?> GetLatestBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)
+        public static async Task<(beatmapset_version, PackageFile[])?> GetLatestBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)
         {
-            return await db.QuerySingleOrDefaultAsync<beatmapset_version?>(
+            var version = await db.QuerySingleOrDefaultAsync<beatmapset_version?>(
                 "SELECT * FROM `beatmapset_versions` WHERE `beatmapset_id` = @beatmapset_id ORDER BY `version_id` DESC LIMIT 1",
                 new
                 {
                     beatmapset_id = beatmapSetId
                 },
                 transaction);
+
+            if (version == null)
+                return null;
+
+            return (version, await getVersionFiles(db, version, transaction));
         }
 
         public static async Task<(beatmapset_version, PackageFile[])?> GetBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, ulong versionId, MySqlTransaction? transaction = null)
@@ -301,6 +306,11 @@ namespace osu.Server.BeatmapSubmission
             if (version == null)
                 return null;
 
+            return (version, await getVersionFiles(db, version, transaction));
+        }
+
+        private static async Task<PackageFile[]> getVersionFiles(MySqlConnection db, beatmapset_version version, MySqlTransaction? transaction = null)
+        {
             PackageFile[] files = (await db.QueryAsync(
                 """
                 SELECT `f`.`file_id`, `f`.`sha2_hash`, `f`.`file_size`, `vf`.`file_id` AS `versioned_file_id`, `vf`.`version_id`, `vf`.`filename` FROM `beatmapset_files` `f`
@@ -314,8 +324,7 @@ namespace osu.Server.BeatmapSubmission
                 },
                 transaction,
                 splitOn: "versioned_file_id")).ToArray();
-
-            return (version, files);
+            return files;
         }
 
         public static async Task<ulong> CreateBeatmapsetVersionAsync(this MySqlConnection db, uint beatmapSetId, MySqlTransaction? transaction = null)

--- a/osu.Server.BeatmapSubmission/Models/PackageFile.cs
+++ b/osu.Server.BeatmapSubmission/Models/PackageFile.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections;
 using osu.Server.BeatmapSubmission.Models.Database;
 using osu.Server.BeatmapSubmission.Services;
 
@@ -11,5 +12,17 @@ namespace osu.Server.BeatmapSubmission.Models
         public beatmapset_file File { get; } = file;
         public beatmapset_version_file VersionFile { get; } = versionFile;
         public BeatmapContent? BeatmapContent { get; } = beatmapContent;
+    }
+
+    public class PackageFileEqualityComparer : IEqualityComparer<PackageFile>
+    {
+        public bool Equals(PackageFile first, PackageFile second)
+        {
+            return first.File.sha2_hash.SequenceEqual(second.File.sha2_hash)
+                   && first.File.file_size == second.File.file_size
+                   && first.VersionFile.filename == second.VersionFile.filename;
+        }
+
+        public int GetHashCode(PackageFile file) => HashCode.Combine(StructuralComparisons.StructuralEqualityComparer.GetHashCode(file.File.sha2_hash), file.File.file_size, file.VersionFile.filename);
     }
 }

--- a/osu.Server.BeatmapSubmission/Services/IBeatmapStorage.cs
+++ b/osu.Server.BeatmapSubmission/Services/IBeatmapStorage.cs
@@ -2,15 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Server.BeatmapSubmission.Models;
-using osu.Server.BeatmapSubmission.Models.API.Responses;
 
 namespace osu.Server.BeatmapSubmission.Services
 {
     public interface IBeatmapStorage
     {
         Task StoreBeatmapSetAsync(uint beatmapSetId, byte[] beatmapPackage);
-
-        IEnumerable<BeatmapSetFile> ListBeatmapSetFiles(uint beatmapSetId);
 
         Task ExtractBeatmapSetAsync(uint beatmapSetId, string targetDirectory);
 

--- a/osu.Server.BeatmapSubmission/Services/ILegacyIO.cs
+++ b/osu.Server.BeatmapSubmission/Services/ILegacyIO.cs
@@ -8,6 +8,7 @@ namespace osu.Server.BeatmapSubmission.Services
         Task DisqualifyBeatmapSetAsync(uint beatmapSetId, string message);
         Task BroadcastReviveBeatmapSetEventAsync(uint beatmapSetId);
         Task BroadcastNewBeatmapSetEventAsync(uint beatmapSetId);
+        Task BroadcastUpdateBeatmapSetEventAsync(uint beatmapSetId, uint userId);
         Task IndexBeatmapSetAsync(uint beatmapSetId);
         Task RefreshBeatmapSetCacheAsync(uint beatmapSetId);
     }

--- a/osu.Server.BeatmapSubmission/Services/LegacyIO.cs
+++ b/osu.Server.BeatmapSubmission/Services/LegacyIO.cs
@@ -87,10 +87,13 @@ namespace osu.Server.BeatmapSubmission.Services
             => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/disqualify", new { message = message });
 
         public async Task BroadcastReviveBeatmapSetEventAsync(uint beatmapSetId)
-            => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/broadcast-revive");
+            => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/broadcast-revive", new { create_event = true });
 
         public async Task BroadcastNewBeatmapSetEventAsync(uint beatmapSetId)
-            => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/broadcast-new");
+            => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/broadcast-new", new { create_event = true });
+
+        public async Task BroadcastUpdateBeatmapSetEventAsync(uint beatmapSetId, uint userId)
+            => await runLegacyIO(HttpMethod.Post, $"beatmapsets/{beatmapSetId}/broadcast-update", new { user_id = userId });
 
         public async Task IndexBeatmapSetAsync(uint beatmapSetId)
             => await runLegacyIO(HttpMethod.Post, $"index-beatmapset/{beatmapSetId}");

--- a/osu.Server.BeatmapSubmission/Services/LocalBeatmapStorage.cs
+++ b/osu.Server.BeatmapSubmission/Services/LocalBeatmapStorage.cs
@@ -6,7 +6,6 @@ using osu.Framework.Extensions;
 using osu.Game.IO.Archives;
 using osu.Server.BeatmapSubmission.Configuration;
 using osu.Server.BeatmapSubmission.Models;
-using osu.Server.BeatmapSubmission.Models.API.Responses;
 using SharpCompress.Writers;
 using SharpCompress.Writers.Zip;
 
@@ -42,24 +41,6 @@ namespace osu.Server.BeatmapSubmission.Services
                 using var targetStream = File.OpenWrite(targetPath);
                 await sourceStream.CopyToAsync(targetStream);
             }
-        }
-
-        public IEnumerable<BeatmapSetFile> ListBeatmapSetFiles(uint beatmapSetId)
-        {
-            string path = getPathToPackage(beatmapSetId);
-
-            if (!File.Exists(path))
-                return [];
-
-            using var stream = File.OpenRead(path);
-            using var archive = new ZipArchiveReader(stream);
-
-            var result = new List<BeatmapSetFile>();
-
-            foreach (string filename in archive.Filenames)
-                result.Add(new BeatmapSetFile(filename, archive.GetStream(filename).ComputeSHA2Hash()));
-
-            return result;
         }
 
         public async Task ExtractBeatmapSetAsync(uint beatmapSetId, string targetDirectory)


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu-server-beatmap-submission/pull/11

- Use versioning database tables for listing latest package version contents rather than the actual package itself. This is desirable because in production this is going to hit S3 to get the package rather than the filesystem and hitting S3 is very likely going to be slower.
- When performing package updates, actually check that there are any meaningful changes to the package. If there are none, skip every database update call & remote procedure calls.