### PR TITLE
Add rate limiting

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using MySqlConnector;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
@@ -54,6 +55,7 @@ namespace osu.Server.BeatmapSubmission
         [Produces("application/json")]
         [ProducesResponseType(typeof(PutBeatmapSetResponse), 200)]
         [ProducesResponseType(typeof(ErrorResponse), 422)]
+        [EnableRateLimiting(Program.RATE_LIMIT_POLICY)]
         public async Task<IActionResult> PutBeatmapSetAsync([FromBody] PutBeatmapSetRequest request)
         {
             uint userId = User.GetUserId();
@@ -192,6 +194,7 @@ namespace osu.Server.BeatmapSubmission
         [Route("beatmapsets/{beatmapSetId}")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ErrorResponse), 422)]
+        [EnableRateLimiting(Program.RATE_LIMIT_POLICY)]
         public async Task<IActionResult> UploadFullPackageAsync(
             [FromRoute] uint beatmapSetId,
             // TODO: this won't fly on production, biggest existing beatmap archives exceed buffering limits (`MultipartBodyLengthLimit` = 128MB specifically)
@@ -257,6 +260,7 @@ namespace osu.Server.BeatmapSubmission
         [Route("beatmapsets/{beatmapSetId}")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ErrorResponse), 422)]
+        [EnableRateLimiting(Program.RATE_LIMIT_POLICY)]
         public async Task<IActionResult> PatchPackageAsync(
             [FromRoute] uint beatmapSetId,
             IFormFileCollection filesChanged,
@@ -314,6 +318,7 @@ namespace osu.Server.BeatmapSubmission
         [Route("beatmapsets/{beatmapSetId}/beatmaps/{beatmapId}")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ErrorResponse), 422)]
+        [EnableRateLimiting(Program.RATE_LIMIT_POLICY)]
         public async Task<IActionResult> UploadGuestDifficultyAsync(
             [FromRoute] uint beatmapSetId,
             [FromRoute] uint beatmapId,

--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -94,9 +94,9 @@ namespace osu.Server.BeatmapSubmission
 
                         return RateLimitPartition.GetSlidingWindowLimiter(userId, _ => new SlidingWindowRateLimiterOptions
                         {
-                            PermitLimit = 30,
+                            PermitLimit = 6,
                             Window = TimeSpan.FromMinutes(1),
-                            SegmentsPerWindow = 6,
+                            SegmentsPerWindow = 3,
                             QueueLimit = 0,
                         });
                     });

--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Reflection;
+using System.Threading.RateLimiting;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,8 @@ namespace osu.Server.BeatmapSubmission
     [UsedImplicitly]
     public class Program
     {
+        public const string RATE_LIMIT_POLICY = "SlidingWindowRateLimiter";
+
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
@@ -81,6 +84,24 @@ namespace osu.Server.BeatmapSubmission
                 }
             }
 
+            builder.Services.AddRateLimiter(options =>
+            {
+                options.RejectionStatusCode = (int)HttpStatusCode.TooManyRequests;
+                options.AddPolicy(RATE_LIMIT_POLICY,
+                    ctx =>
+                    {
+                        uint userId = ctx.User.GetUserId();
+
+                        return RateLimitPartition.GetSlidingWindowLimiter(userId, _ => new SlidingWindowRateLimiterOptions
+                        {
+                            PermitLimit = 30,
+                            Window = TimeSpan.FromMinutes(1),
+                            SegmentsPerWindow = 6,
+                            QueueLimit = 0,
+                        });
+                    });
+            });
+
             if (AppSettings.SentryDsn != null)
             {
                 builder.Services.AddSingleton<ISentryUserFactory, UserFactory>();
@@ -117,6 +138,7 @@ namespace osu.Server.BeatmapSubmission
 
             app.UseAuthorization();
             app.MapControllers();
+            app.UseRateLimiter();
 
             app.Run();
         }


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?view=aspnetcore-9.0 for more information on this.

I've never really tried this in production anywhere, but given it's in ASP.NET Core built-in, I'd hope it should be solid enough?

Limits mostly taken out of rear, and likely are much too lenient anyway. The hard limit is 30 requests/min, with 5 requests being replenished back to the tally every 10 seconds. The limit is enforced per user.