### PR TITLE
Enable HTTP logging

### DIFF
--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -29,6 +29,7 @@ namespace osu.Server.BeatmapSubmission
             {
                 options.Filters.Add<InvariantExceptionFilter>();
             });
+            builder.Services.AddHttpLogging(_ => { });
             builder.Services.AddLogging(logging =>
             {
                 logging.ClearProviders();
@@ -171,6 +172,7 @@ namespace osu.Server.BeatmapSubmission
 
             app.UseAuthorization();
             app.MapControllers();
+            app.UseHttpLogging();
             app.UseRateLimiter();
 
             app.Run();

--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading.RateLimiting;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.Extensions.Options;
 using osu.Server.BeatmapSubmission.Authentication;
 using osu.Server.BeatmapSubmission.Configuration;
@@ -29,7 +30,10 @@ namespace osu.Server.BeatmapSubmission
             {
                 options.Filters.Add<InvariantExceptionFilter>();
             });
-            builder.Services.AddHttpLogging(_ => { });
+            builder.Services.AddHttpLogging(logging =>
+            {
+                logging.LoggingFields = HttpLoggingFields.All;
+            });
             builder.Services.AddLogging(logging =>
             {
                 logging.ClearProviders();


### PR DESCRIPTION
For purposes of debugging why things no work on staging even though they very much do on my machine.

The code change does nothing by itself by default. Enable by setting the envvar

	Logging__LogLevel__Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware=Information

May back this out later once it's deemed no longer required, so didn't bother gating this behind further configuration.