### PR TITLE
Do not purge beatmap if about to update it

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -74,7 +74,7 @@ namespace osu.Server.BeatmapSubmission
 
             using var transaction = await db.BeginTransactionAsync();
 
-            uint[] purgedMaps = await db.PurgeInactiveBeatmapSetsForUserAsync(userId, transaction);
+            uint[] purgedMaps = await db.PurgeInactiveBeatmapSetsForUserAsync(userId, excludedSetIds: beatmapSetId == null ? [] : [beatmapSetId.Value], transaction);
             if (purgedMaps.Length > 0)
                 logger.LogInformation("Purging inactive beatmap sets for user {userId} (ids: {purgedMaps})", userId, purgedMaps);
 


### PR DESCRIPTION
Noticed in passing when attempting to debug the staging deployment failures.

The `PUT /beatmapsets` endpoint that's responsible for assigning IDs to beatmap sets and beatmaps before the full package is uploaded also purges garbage rows from potential previous submission failures (e.g. rows with `active = -1` set).

However if the endpoint is given the set ID of such a garbage row, it will first run the purge, which will delete the row, but then notice that it just deleted the row, and just give up by 404ing.

This is both kinda stupid and undesirable; consider someone submitting a beatmap, where the first request succeeds, and the second fails. With `master` behaviour, this results in a basically unrecoverable state if the user doesn't know how submission internals work. With the behaviour introduced in this PR, all that is required to resolve the situation is to just try again.

This is 100% a carryover from osu-web-10 logic which does the exact same thing, and maybe a reason why people resort to manual `OnlineID` reuses which are notorious for breaking everything.