### PR TITLE
Rename `{ -> Soft`}DeleteBeatmapAsync()`

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -148,7 +148,7 @@ namespace osu.Server.BeatmapSubmission
             {
                 logger.LogInformation("Deleting beatmaps {beatmapIds} in set {beatmapSetId}", beatmapsToDelete, beatmapSetId);
                 foreach (uint beatmapId in beatmapsToDelete)
-                    await db.DeleteBeatmapAsync(beatmapId, transaction);
+                    await db.SoftDeleteBeatmapAsync(beatmapId, transaction);
             }
 
             var beatmapIds = new List<uint>();

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -215,7 +215,7 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
-        public static Task DeleteBeatmapAsync(this MySqlConnection db, uint beatmapId, MySqlTransaction? transaction = null)
+        public static Task SoftDeleteBeatmapAsync(this MySqlConnection db, uint beatmapId, MySqlTransaction? transaction = null)
         {
             return db.ExecuteAsync("UPDATE `osu_beatmaps` SET `deleted_at` = NOW() WHERE `beatmap_id` = @beatmapId",
                 new


### PR DESCRIPTION
That's what it already was, but maybe the name is not the most fortunate, to the point where I confused myself into thinking this method did hard deletion when checking this code quickly (it doesn't).