### PR TITLE
Bump incoming file size limit to 200MB

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -199,10 +199,6 @@ namespace osu.Server.BeatmapSubmission
         [EnableRateLimiting(Program.RATE_LIMIT_POLICY)]
         public async Task<IActionResult> UploadFullPackageAsync(
             [FromRoute] uint beatmapSetId,
-            // TODO: this won't fly on production, biggest existing beatmap archives exceed buffering limits (`MultipartBodyLengthLimit` = 128MB specifically)
-            // potentially also https://github.com/aspnet/Announcements/issues/267
-            // see: https://learn.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads?view=aspnetcore-8.0#small-and-large-files
-            // needs further testing
             IFormFile beatmapArchive)
         {
             uint userId = User.GetUserId();

--- a/osu.Server.BeatmapSubmission/Program.cs
+++ b/osu.Server.BeatmapSubmission/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading.RateLimiting;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.Extensions.Options;
 using osu.Server.BeatmapSubmission.Authentication;
@@ -17,7 +18,7 @@ namespace osu.Server.BeatmapSubmission
     public class Program
     {
         public const string RATE_LIMIT_POLICY = "SlidingWindowRateLimiter";
-
+        public const int ABSOLUTE_REQUEST_SIZE_LIMIT_BYTES = 200_000_000;
         public const string INTEGRATION_TEST_ENVIRONMENT = "IntegrationTest";
 
         public static void Main(string[] args)
@@ -168,6 +169,9 @@ namespace osu.Server.BeatmapSubmission
                     }
                 });
             }
+
+            builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = ABSOLUTE_REQUEST_SIZE_LIMIT_BYTES);
+            builder.Services.Configure<FormOptions>(options => options.MultipartBodyLengthLimit = ABSOLUTE_REQUEST_SIZE_LIMIT_BYTES);
 
             var app = builder.Build();
 


### PR DESCRIPTION
Would close https://github.com/ppy/osu-server-beatmap-submission/issues/32.

The ASP.NET docs on this [have an example of how to do streaming for large uploads](https://learn.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads?view=aspnetcore-8.0#upload-large-files-with-streaming) but it looks terribly complicated and this is just basically two lines of configuration, so I'm kinda willing to try the simple option and seeing how badly it folds in practice?

Limit is set to 200MB to match cloudflare & nginx, at @ThePooN's [suggestion](https://discord.com/channels/90072389919997952/983550677794050108/1341831427586658344).