### PR TITLE
Fix validation attributes crashing on overflow

### DIFF
--- a/osu.Server.BeatmapSubmission.Tests/ValidationTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/ValidationTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel.DataAnnotations;
+using osu.Server.BeatmapSubmission.Models.Database;
+
+namespace osu.Server.BeatmapSubmission.Tests
+{
+    public class ValidationTest
+    {
+        [Fact]
+        public void TestValidationRange()
+        {
+            var beatmap = new osu_beatmap
+            {
+                beatmap_id = 100000,
+                filename = "100000.osu",
+                checksum = "deadbeef",
+                version = "a version",
+                diff_drain = 5,
+                diff_size = 5,
+                diff_overall = 5,
+                diff_approach = 5,
+                bpm = 120,
+                total_length = (uint)int.MaxValue + 1,
+                hit_length = (uint)int.MaxValue + 1,
+                playmode = 1,
+            };
+
+            var errors = new List<ValidationResult>();
+            bool success = Validator.TryValidateObject(beatmap, new ValidationContext(beatmap), errors, validateAllProperties: true);
+
+            Assert.False(success);
+        }
+    }
+}

--- a/osu.Server.BeatmapSubmission/Models/Database/osu_beatmap.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/osu_beatmap.cs
@@ -24,22 +24,22 @@ namespace osu.Server.BeatmapSubmission.Models.Database
         [Romanised(ErrorMessage = "Difficulty name contains disallowed characters.")]
         public string version { get; set; } = string.Empty;
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap is too long.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap is too long.")]
         public uint total_length { get; set; }
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap is too long.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap is too long.")]
         public uint hit_length { get; set; }
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap has too many objects.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap has too many objects.")]
         public uint countTotal { get; set; }
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap has too many objects.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap has too many objects.")]
         public uint countNormal { get; set; }
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap has too many objects.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap has too many objects.")]
         public uint countSlider { get; set; }
 
-        [Range(0, 16777215, ErrorMessage = "The beatmap has too many objects.")]
+        [Range(typeof(uint), "0", "16777215", ErrorMessage = "The beatmap has too many objects.")]
         public uint countSpinner { get; set; }
 
         [Range(0.0, 10.0, ErrorMessage = "The drain rate of the beatmap is out of range.")]


### PR DESCRIPTION
Closes https://github.com/ppy/osu-server-beatmap-submission/issues/42.

This is a bit of a dumb one unfortunately...

`RangeAttribute` has 2 constructors that accept number literals; one takes `int`s and one takes `double`s. The actual range comparison later on uses a bunch of type conversion magic and such, and the conversion takes place either using `int` or `double`. In this case, quantities out of range of `int` but *in* range of `uint` were failing on attempts to convert them to `int` before even attempting to compare them to the range bounds specified.

There's a third constructor of `RangeAttribute` that accepts a type and two... strings (okay, that's probably an attribute limitation, but *weird*). Which should not die in this way, so we use it.