### PR TITLE
Show better error message on exceeding absolute request body cap

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -493,22 +493,8 @@ namespace osu.Server.BeatmapSubmission
             if (packageSizeBytes > allowableSizeBytes)
             {
                 throw new InvariantException($"The beatmap package is too large. "
-                                             + $"The size of the package with the requested changes applied is {humaniseSize(packageSizeBytes)}. "
-                                             + $"The maximum allowable size is {humaniseSize(allowableSizeBytes)}.");
-            }
-
-            static string humaniseSize(double sizeBytes)
-            {
-                string humanisedSize;
-
-                if (sizeBytes < 1024)
-                    humanisedSize = $@"{sizeBytes}B";
-                else if (sizeBytes < 1024 * 1024)
-                    humanisedSize = $@"{sizeBytes / 1024:#.0}kB";
-                else
-                    humanisedSize = $@"{sizeBytes / 1024 / 1024:#.0}MB";
-
-                return humanisedSize;
+                                             + $"The size of the package with the requested changes applied is {FormatUtils.HumaniseSize(packageSizeBytes)}. "
+                                             + $"The maximum allowable size is {FormatUtils.HumaniseSize(allowableSizeBytes)}.");
             }
         }
 

--- a/osu.Server.BeatmapSubmission/FormatUtils.cs
+++ b/osu.Server.BeatmapSubmission/FormatUtils.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.BeatmapSubmission
+{
+    public class FormatUtils
+    {
+        public static string HumaniseSize(double sizeBytes)
+        {
+            string humanisedSize;
+
+            if (sizeBytes < 1024)
+                humanisedSize = $@"{sizeBytes}B";
+            else if (sizeBytes < 1024 * 1024)
+                humanisedSize = $@"{sizeBytes / 1024:#.0}kB";
+            else
+                humanisedSize = $@"{sizeBytes / 1024 / 1024:#.0}MB";
+
+            return humanisedSize;
+        }
+    }
+}

--- a/osu.Server.BeatmapSubmission/ModelStateValidationFilter.cs
+++ b/osu.Server.BeatmapSubmission/ModelStateValidationFilter.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using osu.Server.BeatmapSubmission.Models.API.Responses;
 
 namespace osu.Server.BeatmapSubmission
 {
@@ -28,7 +29,15 @@ namespace osu.Server.BeatmapSubmission
                     continue;
 
                 foreach (var error in value.Errors)
+                {
+                    if (string.IsNullOrEmpty(key) && (error.ErrorMessage.Contains("Request body too large") || error.ErrorMessage.Contains("Multipart body length limit")))
+                    {
+                        context.Result = new ErrorResponse($"Request body too large. Size must be lower than {FormatUtils.HumaniseSize(Program.ABSOLUTE_REQUEST_SIZE_LIMIT_BYTES)}.").ToActionResult();
+                        return;
+                    }
+
                     errorList.Add($"{{ field: \"{key}\", message: \"{error.ErrorMessage}\", exception: \"{error.Exception}\" }}");
+                }
             }
 
             logger.LogError($"""


### PR DESCRIPTION
This got dinged a few times yesterday on sentry (https://sentry.ppy.sh/organizations/ppy/issues/73418/?project=12) because somebody hit the absolute 200MB cap a few times.

This change is designed to (a) stop that from dinging on sentry because there's really no reason to log it as error, and (b) give the user a better error message to work with because the current one was kinda opaque (would just show "BadRequest" or similar).