### PR TITLE
Fix incorrect validation of circle size / key count

### DIFF
--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -1572,6 +1572,75 @@ namespace osu.Server.BeatmapSubmission.Tests
             Assert.Contains("At least one difficulty has a specified creator that isn't the beatmap host's username.", (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
         }
 
+        [Theory]
+        [InlineData(0, 0.3, true)]
+        [InlineData(0, 10, true)]
+        [InlineData(3, 2, true)]
+        [InlineData(3, 7.5, false)]
+        [InlineData(3, 18, true)]
+        public async Task TestPatchPackage_FailsOnIncorrectCircleSize(short playmode, float circleSize, bool shouldSucceed)
+        {
+            using var db = await DatabaseAccess.GetConnectionAsync();
+            await db.ExecuteAsync("INSERT INTO `phpbb_users` (`user_id`, `username`, `username_clean`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (1000, 'test', 'test', 'JP', '', '', '', '')");
+
+            await db.ExecuteAsync(@"INSERT INTO `osu_beatmapsets` (`beatmapset_id`, `user_id`, `creator`, `approved`, `thread_id`, `active`, `submit_date`) VALUES (241526, 1000, 'test user', -1, 0, -1, CURRENT_TIMESTAMP)");
+
+            foreach (uint beatmapId in new uint[] { 557815, 557814, 557821, 557816, 557817, 557818, 557812, 557810, 557811, 557820, 557813, 557819 })
+                await db.ExecuteAsync(@"INSERT INTO `osu_beatmaps` (`beatmap_id`, `user_id`, `beatmapset_id`, `approved`) VALUES (@beatmapId, 1000, 241526, -1)", new { beatmapId = beatmapId });
+
+            using (var dstStream = File.OpenWrite(Path.Combine(beatmapStorage.BaseDirectory, "241526")))
+            using (var srcStream = TestResources.GetResource(osz_filename)!)
+                await srcStream.CopyToAsync(dstStream);
+            await db.ExecuteAsync(@"INSERT INTO `beatmapset_versions` (`beatmapset_id`) VALUES (241526)");
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, "/beatmapsets/241526");
+
+            using var content = new MultipartFormDataContent($"{Guid.NewGuid()}----");
+            content.Add(new StringContent(
+                $"""
+                osu file format v14
+                
+                [General]
+                Mode:{playmode}
+                
+                [Metadata]
+                Title:Renatus
+                TitleUnicode:Renatus
+                Artist:Soleily
+                ArtistUnicode:Soleily
+                Creator:test
+                Version:Platter 2
+                Source:
+                Tags:MBC7 Unisphere 地球ヤバイEP Chikyu Yabai
+                BeatmapID:557810
+                BeatmapSetID:241526
+                
+                [Difficulty]
+                HPDrainRate:5
+                CircleSize:{circleSize}
+                OverallDifficulty:8
+                ApproachRate:8
+                SliderMultiplier:1.75
+                SliderTickRate:2
+                """
+            ), "filesChanged", osu_filename);
+            content.Add(new StringContent("Soleily - Renatus (test) [Platter].osu"), "filesDeleted");
+            request.Content = content;
+            request.Headers.Add(HeaderBasedAuthenticationHandler.USER_ID_HEADER, "1000");
+
+            var response = await Client.SendAsync(request);
+
+            if (shouldSucceed)
+                Assert.True(response.IsSuccessStatusCode);
+            else
+            {
+                Assert.False(response.IsSuccessStatusCode);
+
+                Assert.Contains(playmode == 3 ? "The circle size of the beatmap is out of range." : "The key count of the beatmap is invalid.",
+                    (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
+            }
+        }
+
         [Fact]
         public async Task TestSubmitGuestDifficulty_OldStyle()
         {

--- a/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
+++ b/osu.Server.BeatmapSubmission.Tests/BeatmapSubmissionControllerTest.cs
@@ -1636,7 +1636,7 @@ namespace osu.Server.BeatmapSubmission.Tests
             {
                 Assert.False(response.IsSuccessStatusCode);
 
-                Assert.Contains(playmode == 3 ? "The circle size of the beatmap is out of range." : "The key count of the beatmap is invalid.",
+                Assert.Contains(playmode == 3 ? "The key count of the beatmap is invalid." : "The circle size of the beatmap is out of range.",
                     (await response.Content.ReadFromJsonAsync<ErrorResponse>())!.Error);
             }
         }

--- a/osu.Server.BeatmapSubmission/Models/Database/osu_beatmap.cs
+++ b/osu.Server.BeatmapSubmission/Models/Database/osu_beatmap.cs
@@ -5,11 +5,12 @@
 
 using System.ComponentModel.DataAnnotations;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
 using osu.Server.BeatmapSubmission.Models.Database.Validation;
 
 namespace osu.Server.BeatmapSubmission.Models.Database
 {
-    public class osu_beatmap
+    public class osu_beatmap : IValidatableObject
     {
         public uint beatmap_id { get; set; }
         public uint? beatmapset_id { get; set; }
@@ -45,7 +46,6 @@ namespace osu.Server.BeatmapSubmission.Models.Database
         [Range(0.0, 10.0, ErrorMessage = "The drain rate of the beatmap is out of range.")]
         public float diff_drain { get; set; }
 
-        [Range(1.0, 18.0, ErrorMessage = "The circle size / key count of the beatmap is out of range.")]
         public float diff_size { get; set; }
 
         [Range(0.0, 10.0, ErrorMessage = "The overall difficulty of the beatmap is out of range.")]
@@ -69,5 +69,29 @@ namespace osu.Server.BeatmapSubmission.Models.Database
         // deleted_at skipped on purpose
 
         public float bpm { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            switch (playmode)
+            {
+                case 0:
+                case 1:
+                case 2:
+                {
+                    if (diff_size < 0 || diff_size > 10)
+                        yield return new ValidationResult("The circle size of the beatmap is out of range.");
+
+                    break;
+                }
+
+                case 3:
+                {
+                    if (diff_size != (int)diff_size || diff_size < 1 || diff_size > LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT)
+                        yield return new ValidationResult("The key count of the beatmap is invalid.");
+
+                    break;
+                }
+            }
+        }
     }
 }

--- a/osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj
+++ b/osu.Server.BeatmapSubmission/osu.Server.BeatmapSubmission.csproj
@@ -19,11 +19,11 @@
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10"/>
-        <PackageReference Include="ppy.osu.Game" Version="2025.304.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.304.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.304.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.304.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.304.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.420.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.420.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.420.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.420.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.420.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="5.2.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />


### PR DESCRIPTION
The big issue is that the range specified on the attribute was [1, 18] which only makes sense in mania.

The small issue that while the range was checked, nothing decimal should really be allowed for mania anyway.

A significant amount of this is kind of much-of-muchness because `LegacyBeatmapDecoder` [already does clamping on this](https://github.com/ppy/osu/blob/834d63d1deacf0be0c4e76cd5d47cee136fbb49a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs#L113-L131), so the checks are kind of dead in practice, but I'd rather have them not, what with users' propensity to [try and break stuff and not have us notice that it happened](https://github.com/ppy/osu/issues/32891).

The game package bump here is significant because it exposes `LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT`.