### PR TITLE
Bump beatmap set last update date even if the contents didn't change

### DIFF
--- a/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
+++ b/osu.Server.BeatmapSubmission/BeatmapSubmissionController.cs
@@ -421,7 +421,8 @@ namespace osu.Server.BeatmapSubmission
 
                 if (fileSet.SetEquals(parseResult.Files))
                 {
-                    await transaction.RollbackAsync();
+                    await db.MarkBeatmapSetUpdatedAsync(beatmapSet, transaction);
+                    await transaction.CommitAsync();
                     return false;
                 }
             }

--- a/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
+++ b/osu.Server.BeatmapSubmission/DatabaseOperationExtensions.cs
@@ -295,6 +295,17 @@ namespace osu.Server.BeatmapSubmission
                 transaction);
         }
 
+        /// <summary>
+        /// Only bumps the <paramref name="beatmapset"/>'s <c>last_update</c> date without performing any other changes.
+        /// Used in scenarios where a submission occurred for a beatmap with no changes.
+        /// Bumping the update date is important in such cases, because if it is e.g. an update after reviving the beatmap,
+        /// not bumping the update date will cause the beatmap to move to the graveyard again on the next day after the update.
+        /// </summary>
+        public static Task MarkBeatmapSetUpdatedAsync(this MySqlConnection db, osu_beatmapset beatmapset, MySqlTransaction? transaction = null)
+        {
+            return db.ExecuteAsync("UPDATE `osu_beatmapsets` SET `last_update` = CURRENT_TIMESTAMP WHERE `beatmapset_id` = @beatmapset_id", beatmapset, transaction);
+        }
+
         public static async Task<ulong> InsertBeatmapsetFileAsync(this MySqlConnection db, beatmapset_file file, MySqlTransaction? transaction = null)
         {
             var existing = await db.QuerySingleOrDefaultAsync<beatmapset_file?>(


### PR DESCRIPTION
This matters in one specific case - if the no-op update also happened to ungraveyard the set in question, not bumping the last update date will cause the set to re-enter the graveyard the very next day due to [web-10 logic being based around last update date](https://github.com/peppy/osu-web-10/blob/2723bd9f63e243c506336494509d1b72fb92872d/www/web/update_forums.php#L31), which does not seem to match the intention of the user when updating a graveyarded beatmap like that.